### PR TITLE
organize workshops into tracks

### DIFF
--- a/source/_events/20180920-0900-mc-cogs.md
+++ b/source/_events/20180920-0900-mc-cogs.md
@@ -2,8 +2,8 @@
 permalink: none
 slug:
 
-title: "ARD Workshop: COGs"
-type: Workshop
+title: "Cloud Optimized GeoTIFF"
+type: "Workshop Track: Analysis Ready Data" 
 category:
 date: "2018-09-20"
 time: "09:00"
@@ -11,6 +11,6 @@ time_slot: "09:00"
 duration:
 room: Meridian C
 speakers:
-summary: "The Cloud Optimized Geotiff (COG) format is a way to store satellite data to allow for fast web access and cloud analysis at scale. Adopted widely by the Earth on AWS effort, it immediately enabled new forms of access and use of imagery data. We will share Mapbox’s experience working with COGs. We’ll also cover how to create them from other formats and how to use them in your application."
+summary: "The Cloud-Optimized GeoTIFF (COG) format is a way to store satellite data to allow for fast web access and cloud analysis at scale. Adopted widely by the Earth on AWS effort, it immediately enabled new forms of access and use of imagery data. We will share Mapbox’s experience working with COGs. We’ll also cover how to create them from other formats and how to use them in your application."
 ---
-The Cloud Optimized Geotiff (COG) format is a way to store satellite data to allow for fast web access and cloud analysis at scale. Adopted widely by the Earth on AWS effort, it immediately enabled new forms of access and use of imagery data. We will share Mapbox’s experience working with COGs. We’ll also cover how to create them from other formats and how to use them in your application.
+The Cloud Optimized GeoTIFF (COG) format is a way to store satellite data to allow for fast web access and cloud analysis at scale. Adopted widely by the Earth on AWS effort, it immediately enabled new forms of access and use of imagery data. We will share Mapbox’s experience working with COGs. We’ll also cover how to create them from other formats and how to use them in your application.

--- a/source/_events/20180920-0900-mde-radiant.md
+++ b/source/_events/20180920-0900-mde-radiant.md
@@ -2,8 +2,8 @@
 permalink: none
 slug:
 
-title: "Analysis at Scale: Radiant Earth Foundation platform"
-type: Workshop
+title: "Radiant Earth Foundation platform"
+type: "Workshop Track: Analysis at Scale"
 category:
 date: "2018-09-20"
 time: "09:00"

--- a/source/_events/20180920-0900-oab-signal-code.md
+++ b/source/_events/20180920-0900-oab-signal-code.md
@@ -3,7 +3,7 @@ permalink: none
 slug:
 
 title: Signal Code, ethical guidelines for humanitarian remote sensing
-type: Workshop
+type: "Workshop Track: Policy and Strategy"
 category:
 date: "2018-09-20"
 time: "09:00"

--- a/source/_events/20180920-1100-mc-datacubes-and-commonsensing.md
+++ b/source/_events/20180920-1100-mc-datacubes-and-commonsensing.md
@@ -2,8 +2,8 @@
 permalink: none
 slug:
 
-title: "ARD Workshop: DataCubes and CommonSensing"
-type: Workshop
+title: "DataCubes and CommonSensing"
+type: "Workshop Track: Analysis Ready Data"
 category:
 date: "2018-09-20"
 time: "11:00"

--- a/source/_events/20180920-1100-mde-rasterio.md
+++ b/source/_events/20180920-1100-mde-rasterio.md
@@ -2,8 +2,8 @@
 permalink: none
 slug:
 
-title: "ML & Analysis Workshop: Rasterio"
-type: Workshop
+title: "Rasterio"
+type: "Workshop Track: Analysis at Scale"
 category:
 date: "2018-09-20"
 time: "11:00"

--- a/source/_events/20180920-1100-oab-gbdx.md
+++ b/source/_events/20180920-1100-oab-gbdx.md
@@ -2,8 +2,8 @@
 permalink: none
 slug:
 
-title: "ML & Analysis Workshop: GBDX"
-type: Workshop
+title: "GBDX"
+type: "Workshop Track: Machine Learning"
 category:
 date: "2018-09-20"
 time: "11:00"

--- a/source/_events/20180920-1300-mc-google-earth-engine-and-python.md
+++ b/source/_events/20180920-1300-mc-google-earth-engine-and-python.md
@@ -2,8 +2,8 @@
 permalink: none
 slug:
 
-title: "ARD Workshop: Google Earth Engine and Python"
-type: Workshop
+title: "Google Earth Engine and Python"
+type: "Workshop Track: Analysis Ready Data"
 category:
 date: "2018-09-20"
 time: "13:00"

--- a/source/_events/20180920-1300-mde-satutils.md
+++ b/source/_events/20180920-1300-mde-satutils.md
@@ -2,8 +2,8 @@
 permalink: none
 slug:
 
-title: "Analysis at Scale: sat-utils"
-type: Workshop
+title: "sat-utils"
+type: "Workshop Track: Analysis at Scale"
 category:
 date: "2018-09-20"
 time: "13:00"

--- a/source/_events/20180920-1300-oab-label-maker-and-robosat.md
+++ b/source/_events/20180920-1300-oab-label-maker-and-robosat.md
@@ -2,8 +2,8 @@
 permalink: none
 slug:
 
-title: "ML & Analysis Workshop: Label Maker and Robosat"
-type: Workshop
+title: "Label Maker and Robosat"
+type: "Workshop Track: Machine Learning"
 category:
 date: "2018-09-20"
 time: "13:00"


### PR DESCRIPTION
@rwoerner @ldgillen proposal for organizing the workshops into tracks. Makes it easier to follow and doesn't bury the substance after after a colon.

![satsummit 2018](https://user-images.githubusercontent.com/1480842/45132537-5a4ff880-b15f-11e8-87db-35587ead3262.png)
