### PR TITLE
Speakers group

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -126,6 +126,10 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
           }
         },
         pronouns: 'String',
+        group: {
+          type: 'String',
+          resolve: (source) => source.group || 'main'
+        },
 
         // Foreign relationship between people and events. This is not a
         // straightforward relation because we need to know what is the role

--- a/src/components/agenda/event-people.js
+++ b/src/components/agenda/event-people.js
@@ -39,7 +39,7 @@ export function EventPeople(props) {
   return (
     <AgendaEntryPeopleList>
       {list.map((person) => {
-        if (person.isVoid) {
+        if (person.isVoid || person.group !== 'main') {
           return (
             <li key={person.title}>
               <strong>{person.title}</strong>

--- a/src/components/agenda/event.js
+++ b/src/components/agenda/event.js
@@ -83,7 +83,7 @@ const AgendaEntryTitle = styled(VarHeading).attrs((props) => {
     size: 'xlarge'
   };
 })`
-  /* styled-components */
+  /* styled-component */
 `;
 
 const AgendaEntryTitleLink = styled(Link)`

--- a/src/pages/agenda.js
+++ b/src/pages/agenda.js
@@ -160,6 +160,7 @@ const AgendaPage = ({ location }) => {
 
   useEffect(() => {
     document.getElementById(location.hash.slice(1))?.scrollIntoView();
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, []);
 
   return (

--- a/src/pages/speakers.js
+++ b/src/pages/speakers.js
@@ -131,10 +131,9 @@ const SpeakerAvatar = styled(PersonAvatar)`
 `;
 
 const SpeakerTitle = styled(VarHeading).attrs({
-  as: 'h2',
+  as: 'h3',
   size: 'large'
 })`
-  /* styled-component */
   line-height: calc(0.5rem + 0.75em);
 `;
 
@@ -147,26 +146,30 @@ const SpeakerSubtitle = styled.p`
   `}
 `;
 
-const SpeakersListCondensed = styled(SpeakersMainList)`
-  grid-template-columns: repeat(3, 1fr);
-
-  ${media.mediumUp`
-    grid-template-columns: repeat(4, 1fr);
-  `}
-
-  ${media.xlargeUp`
-    grid-template-columns: repeat(6, 1fr);
-  `}
-
-  ${SpeakerTitle} {
-    font-size: 1.25rem;
-  }
+const SpeakersOthersList = styled(SpeakersMainList)`
+  /* styled-component */
 `;
 
-const SpeakerInner = styled.div`
+const OthersSpeaker = styled.article`
   display: flex;
   flex-flow: column nowrap;
-  height: 100%;
+`;
+
+const OthersSpeakerHeader = styled.header`
+  display: flex;
+  flex-flow: column nowrap;
+  gap: ${variableGlsp(0.25)};
+`;
+
+const OthersSpeakerTitle = styled(VarHeading).attrs({
+  as: 'h3',
+  size: 'small'
+})`
+  line-height: calc(0.5rem + 0.75em);
+`;
+
+const OthersSpeakerSubtitle = styled(SpeakerSubtitle)`
+  /* styled-component */
 `;
 
 const SpeakersPage = () => {
@@ -254,29 +257,20 @@ const SpeakersPage = () => {
               </SpeakersSectionTitle>
             </SpeakersSectionHeader>
             <SpeakersSectionBody>
-              <SpeakersListCondensed>
+              <SpeakersOthersList>
                 {other.map((speaker) => (
                   <li key={speaker.id}>
-                    <Speaker>
-                      <SpeakerInner>
-                        <SpeakerHeader>
-                          <SpeakerTitle>{speaker.title}</SpeakerTitle>
-                          <SpeakerSubtitle>
-                            {speaker.role} at {speaker.company}
-                          </SpeakerSubtitle>
-                        </SpeakerHeader>
-                        <SpeakerAvatar>
-                          <GatsbyImage
-                            image={getImage(speaker.avatar)}
-                            alt={`Picture of ${speaker.title}`}
-                            objectFit='contain'
-                          />
-                        </SpeakerAvatar>
-                      </SpeakerInner>
-                    </Speaker>
+                    <OthersSpeaker>
+                      <OthersSpeakerHeader>
+                        <OthersSpeakerTitle>{speaker.title}</OthersSpeakerTitle>
+                        <OthersSpeakerSubtitle>
+                          {speaker.role} at {speaker.company}
+                        </OthersSpeakerSubtitle>
+                      </OthersSpeakerHeader>
+                    </OthersSpeaker>
                   </li>
                 ))}
-              </SpeakersListCondensed>
+              </SpeakersOthersList>
             </SpeakersSectionBody>
           </SpeakersSection>
         </SpeakersContent>

--- a/src/pages/speakers.js
+++ b/src/pages/speakers.js
@@ -58,8 +58,8 @@ const SpeakersSection = styled.section`
 `;
 
 const SpeakersSectionHeader = styled.header`
-  ${SpeakersSection}:first-child & {
-    ${visuallyHidden}()
+  ${/* sc-selector */ SpeakersSection}:first-child & {
+    ${visuallyHidden()}
   }
 `;
 

--- a/src/pages/speakers.js
+++ b/src/pages/speakers.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import styled from 'styled-components';
 import { graphql, Link, useStaticQuery } from 'gatsby';
 import { GatsbyImage, getImage } from 'gatsby-plugin-image';
@@ -117,6 +117,35 @@ const SpeakerSubtitle = styled.p`
   `}
 `;
 
+const SpeakerSecondaryTitle = styled(VarHeading).attrs({
+  as: 'h2',
+  size: 'xlarge'
+})`
+  grid-column: content-start / content-end;
+`;
+
+const SpeakersListCondensed = styled(SpeakersList)`
+  grid-template-columns: repeat(3, 1fr);
+
+  ${media.mediumUp`
+    grid-template-columns: repeat(4, 1fr);
+  `}
+
+  ${media.xlargeUp`
+    grid-template-columns: repeat(6, 1fr);
+  `}
+
+  ${SpeakerTitle} {
+    font-size: 1.25rem;
+  }
+`;
+
+const SpeakerInner = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  height: 100%;
+`;
+
 const SpeakersPage = () => {
   const { allPeople } = useStaticQuery(graphql`
     query {
@@ -127,15 +156,32 @@ const SpeakersPage = () => {
           title
           avatar {
             childImageSharp {
-              gatsbyImageData(width: 640, placeholder: BLURRED)
+              gatsbyImageData(width: 640, height: 640, placeholder: BLURRED)
             }
           }
           role
           company
+          group
         }
       }
     }
   `);
+
+  const { main, other } = useMemo(
+    () =>
+      allPeople.nodes.reduce(
+        (acc, node) => {
+          if (node.group === 'main') {
+            acc.main.push(node);
+          } else {
+            acc.other.push(node);
+          }
+          return acc;
+        },
+        { main: [], other: [] }
+      ),
+    [allPeople.nodes]
+  );
 
   return (
     <Layout title='Speakers'>
@@ -148,7 +194,7 @@ const SpeakersPage = () => {
 
         <SpeakersBlock>
           <SpeakersList>
-            {allPeople.nodes.map((speaker) => (
+            {main.map((speaker) => (
               <li key={speaker.id}>
                 <Speaker>
                   <SpeakerLink to={`/speakers/${speaker.slug}`}>
@@ -170,6 +216,33 @@ const SpeakersPage = () => {
               </li>
             ))}
           </SpeakersList>
+        </SpeakersBlock>
+
+        <SpeakersBlock>
+          <SpeakerSecondaryTitle>Other</SpeakerSecondaryTitle>
+          <SpeakersListCondensed>
+            {other.map((speaker) => (
+              <li key={speaker.id}>
+                <Speaker>
+                  <SpeakerInner>
+                    <SpeakerHeader>
+                      <SpeakerTitle>{speaker.title}</SpeakerTitle>
+                      <SpeakerSubtitle>
+                        {speaker.role} at {speaker.company}
+                      </SpeakerSubtitle>
+                    </SpeakerHeader>
+                    <SpeakerAvatar>
+                      <GatsbyImage
+                        image={getImage(speaker.avatar)}
+                        alt={`Picture of ${speaker.title}`}
+                        objectFit='contain'
+                      />
+                    </SpeakerAvatar>
+                  </SpeakerInner>
+                </Speaker>
+              </li>
+            ))}
+          </SpeakersListCondensed>
         </SpeakersBlock>
       </PageMainContent>
     </Layout>

--- a/src/pages/speakers.js
+++ b/src/pages/speakers.js
@@ -4,7 +4,6 @@ import { graphql, Link, useStaticQuery } from 'gatsby';
 import { GatsbyImage, getImage } from 'gatsby-plugin-image';
 
 import {
-  glsp,
   listReset,
   media,
   multiply,

--- a/src/pages/speakers.js
+++ b/src/pages/speakers.js
@@ -7,7 +7,8 @@ import {
   listReset,
   media,
   multiply,
-  themeVal
+  themeVal,
+  visuallyHidden
 } from '@devseed-ui/theme-provider';
 
 import Layout from '$components/layout';
@@ -38,13 +39,43 @@ const SpeakersHubHeroHeadline = styled.div`
   `}
 `;
 
-const SpeakersBlock = styled(Hug)`
+const SpeakersContent = styled(Hug)`
   padding: ${variableGlsp(0, 0, 2, 0)};
 `;
 
-const SpeakersList = styled.ol`
-  ${listReset()};
+const SpeakersSection = styled.section`
   grid-column: content-start / content-end;
+  display: flex;
+  flex-flow: column nowrap;
+  gap: ${variableGlsp()};
+
+  &:not(:first-child) {
+    margin-top: ${variableGlsp(1.5)};
+    padding-top: ${variableGlsp(2)};
+    border-top: ${multiply(themeVal('layout.border'), 4)} solid
+      ${themeVal('color.secondary-500')};
+  }
+`;
+
+const SpeakersSectionHeader = styled.header`
+  ${SpeakersSection}:first-child & {
+    ${visuallyHidden}()
+  }
+`;
+
+const SpeakersSectionBody = styled.div`
+  /* styled-components */
+`;
+
+const SpeakersSectionTitle = styled(VarHeading).attrs({
+  as: 'h2',
+  size: 'xlarge'
+})`
+  grid-column: content-start / content-end;
+`;
+
+const SpeakersMainList = styled.ol`
+  ${listReset()};
   display: grid;
   gap: ${variableGlsp()};
   grid-template-columns: repeat(2, 1fr);
@@ -116,14 +147,7 @@ const SpeakerSubtitle = styled.p`
   `}
 `;
 
-const SpeakerSecondaryTitle = styled(VarHeading).attrs({
-  as: 'h2',
-  size: 'xlarge'
-})`
-  grid-column: content-start / content-end;
-`;
-
-const SpeakersListCondensed = styled(SpeakersList)`
+const SpeakersListCondensed = styled(SpeakersMainList)`
   grid-template-columns: repeat(3, 1fr);
 
   ${media.mediumUp`
@@ -191,58 +215,71 @@ const SpeakersPage = () => {
           </SpeakersHubHeroHeadline>
         </PageMainHero>
 
-        <SpeakersBlock>
-          <SpeakersList>
-            {main.map((speaker) => (
-              <li key={speaker.id}>
-                <Speaker>
-                  <SpeakerLink to={`/speakers/${speaker.slug}`}>
-                    <SpeakerHeader>
-                      <SpeakerTitle>{speaker.title}</SpeakerTitle>
-                      <SpeakerSubtitle>
-                        {speaker.role} at {speaker.company}
-                      </SpeakerSubtitle>
-                    </SpeakerHeader>
-                    <SpeakerAvatar>
-                      <GatsbyImage
-                        image={getImage(speaker.avatar)}
-                        alt={`Picture of ${speaker.title}`}
-                        objectFit='contain'
-                      />
-                    </SpeakerAvatar>
-                  </SpeakerLink>
-                </Speaker>
-              </li>
-            ))}
-          </SpeakersList>
-        </SpeakersBlock>
+        <SpeakersContent>
+          <SpeakersSection>
+            <SpeakersSectionHeader>
+              <SpeakersSectionTitle>Main speakers</SpeakersSectionTitle>
+            </SpeakersSectionHeader>
+            <SpeakersSectionBody>
+              <SpeakersMainList>
+                {main.map((speaker) => (
+                  <li key={speaker.id}>
+                    <Speaker>
+                      <SpeakerLink to={`/speakers/${speaker.slug}`}>
+                        <SpeakerHeader>
+                          <SpeakerTitle>{speaker.title}</SpeakerTitle>
+                          <SpeakerSubtitle>
+                            {speaker.role} at {speaker.company}
+                          </SpeakerSubtitle>
+                        </SpeakerHeader>
+                        <SpeakerAvatar>
+                          <GatsbyImage
+                            image={getImage(speaker.avatar)}
+                            alt={`Picture of ${speaker.title}`}
+                            objectFit='contain'
+                          />
+                        </SpeakerAvatar>
+                      </SpeakerLink>
+                    </Speaker>
+                  </li>
+                ))}
+              </SpeakersMainList>
+            </SpeakersSectionBody>
+          </SpeakersSection>
 
-        <SpeakersBlock>
-          <SpeakerSecondaryTitle>Other</SpeakerSecondaryTitle>
-          <SpeakersListCondensed>
-            {other.map((speaker) => (
-              <li key={speaker.id}>
-                <Speaker>
-                  <SpeakerInner>
-                    <SpeakerHeader>
-                      <SpeakerTitle>{speaker.title}</SpeakerTitle>
-                      <SpeakerSubtitle>
-                        {speaker.role} at {speaker.company}
-                      </SpeakerSubtitle>
-                    </SpeakerHeader>
-                    <SpeakerAvatar>
-                      <GatsbyImage
-                        image={getImage(speaker.avatar)}
-                        alt={`Picture of ${speaker.title}`}
-                        objectFit='contain'
-                      />
-                    </SpeakerAvatar>
-                  </SpeakerInner>
-                </Speaker>
-              </li>
-            ))}
-          </SpeakersListCondensed>
-        </SpeakersBlock>
+          <SpeakersSection>
+            <SpeakersSectionHeader>
+              <SpeakersSectionTitle>
+                Other speakers include
+              </SpeakersSectionTitle>
+            </SpeakersSectionHeader>
+            <SpeakersSectionBody>
+              <SpeakersListCondensed>
+                {other.map((speaker) => (
+                  <li key={speaker.id}>
+                    <Speaker>
+                      <SpeakerInner>
+                        <SpeakerHeader>
+                          <SpeakerTitle>{speaker.title}</SpeakerTitle>
+                          <SpeakerSubtitle>
+                            {speaker.role} at {speaker.company}
+                          </SpeakerSubtitle>
+                        </SpeakerHeader>
+                        <SpeakerAvatar>
+                          <GatsbyImage
+                            image={getImage(speaker.avatar)}
+                            alt={`Picture of ${speaker.title}`}
+                            objectFit='contain'
+                          />
+                        </SpeakerAvatar>
+                      </SpeakerInner>
+                    </Speaker>
+                  </li>
+                ))}
+              </SpeakersListCondensed>
+            </SpeakersSectionBody>
+          </SpeakersSection>
+        </SpeakersContent>
       </PageMainContent>
     </Layout>
   );

--- a/src/templates/people-page.js
+++ b/src/templates/people-page.js
@@ -21,7 +21,7 @@ import {
 import Layout from '$components/layout';
 import { AgendaEventList, AgendaEventListItem } from '$components/agenda';
 
-import { PageMainContent, PageMainSubtitle, PageMainTitle } from '$styles/page';
+import { PageMainContent, PageMainTitle } from '$styles/page';
 import { VarHeading, VarProse } from '$styles/variable-components';
 import { PersonAvatar } from '$styles/people';
 import Hug from '$styles/hug';

--- a/src/utils/graphql/fragments.js
+++ b/src/utils/graphql/fragments.js
@@ -5,6 +5,7 @@ export const peopleFields = graphql`
     ... on People {
       title
       slug
+      group
     }
     ... on VoidPeople {
       title


### PR DESCRIPTION
Created a secondary display of speakers below the main one. Any speaker with a group property that is different that `main` will show here.

On the agenda, speakers that do not belong to the `main` group do not appear linked.

@ricardoduplos please have a look at markup and styling for the secondary list. Just add `group: other` to any speaker to have it show up.